### PR TITLE
Fix crash when menu not available

### DIFF
--- a/SNU_DINE/app/src/main/java/jihadi/example/windows7/food/MainActivity.java
+++ b/SNU_DINE/app/src/main/java/jihadi/example/windows7/food/MainActivity.java
@@ -142,7 +142,7 @@ public class MainActivity extends Activity {
 
                 return true;
 
-            } catch (IOException e) {
+            } catch (IOException | IndexOutOfBoundsException e) {
                 e.printStackTrace();
             }
 


### PR DESCRIPTION
Couldn't test as the menu is now available. But most probably this was the cause of the error. 
Fix #4 
